### PR TITLE
Use the term "full resource name"

### DIFF
--- a/aip/0122.md
+++ b/aip/0122.md
@@ -157,7 +157,7 @@ API are expected to use the same underlying data.
 **Note:** The correlation between the full resource name and the service's
 hostname is by convention. In particular, one service is able to have multiple
 hostnames (example use cases include regionalization or staging environments),
-and the full resource does not change between these.
+and the full resource name does not change between these.
 
 ### Fields representing resource names
 


### PR DESCRIPTION
Clarify that the full resource name does not change across multiple hostnames of a service.